### PR TITLE
[EOBS-1870] Create GoCD pipeline for tagging releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 sample_files/.gitignore
 .idea/
+version_branch.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 sample_files/.gitignore
+.idea/

--- a/gocd/Makefile
+++ b/gocd/Makefile
@@ -21,6 +21,11 @@ pylint:
 	${root_path}/venv/bin/pylint --load-plugins=pylint_odoo --rcfile=../travis/cfg/travis_run_pylint.cfg ${root_path}/openeobs
 	${root_path}/venv/bin/pylint --load-plugins=pylint_odoo --rcfile=../travis/cfg/travis_run_pylint.cfg ${root_path}/client_modules
 
+checkout_branches:
+	# If $BRANCH does not exist script will determine branches from GOCD
+	# environment variables.
+	checkout_branches $BRANCH
+
 make_addons_dir:
 	mkdir -p ${root_path}/liveobs_addons
 

--- a/gocd/Makefile
+++ b/gocd/Makefile
@@ -1,6 +1,11 @@
 #!/usr/bin/make
 
+root_path=..
+
 all: create_venv install_deps flake8 pylint make_addons_dir move_addons_into_dir
+
+print_foobar:
+	cat ${root_path}/version_branch.txt
 
 create_venv:
 	virtualenv ${root_path}/venv

--- a/gocd/Makefile
+++ b/gocd/Makefile
@@ -22,10 +22,10 @@ pylint:
 	${root_path}/venv/bin/pylint --load-plugins=pylint_odoo --rcfile=../travis/cfg/travis_run_pylint.cfg ${root_path}/client_modules
 
 checkout_branches:
-	checkout_branches
+	./checkout_branches.sh
 
 checkout_branches_for_release:
-	BRANCH=$(python ../releases/releases/get_latest_version_number.py ../releases/releases.yml) checkout_branches
+	BRANCH=$(python ../releases/releases/get_latest_version_number.py ../releases/releases.yml) ./checkout_branches.sh
 
 make_addons_dir:
 	mkdir -p ${root_path}/liveobs_addons

--- a/gocd/Makefile
+++ b/gocd/Makefile
@@ -6,10 +6,10 @@ create_venv:
 	virtualenv ${root_path}/venv
 
 install_deps:
-	${root_path}/venv/bin/pip install -r ${root_path}/requirements.txt
-	${root_path}/venv/bin/pip install -r ${root_path}/../nhclinical/requirements.txt
-	${root_path}/venv/bin/pip install -r ${root_path}/../openeobs/requirements.txt
-	${root_path}/venv/bin/pip install -r ${root_path}/../BJSS_liveobs_client_modules/requirements.txt
+	${root_path}/venv/bin/pip install -r requirements.txt
+	${root_path}/venv/bin/pip install -r ${root_path}/nhclinical/requirements.txt
+	${root_path}/venv/bin/pip install -r ${root_path}/openeobs/requirements.txt
+	${root_path}/venv/bin/pip install -r ${root_path}/BJSS_liveobs_client_modules/requirements.txt
 
 flake8:
 	${root_path}/venv/bin/flake8 --config=../travis/cfg/travis_run_flake8.cfg ${root_path}/nhclinical

--- a/gocd/Makefile
+++ b/gocd/Makefile
@@ -22,9 +22,10 @@ pylint:
 	${root_path}/venv/bin/pylint --load-plugins=pylint_odoo --rcfile=../travis/cfg/travis_run_pylint.cfg ${root_path}/client_modules
 
 checkout_branches:
-	# If $BRANCH does not exist script will determine branches from GOCD
-	# environment variables.
-	checkout_branches $BRANCH
+	checkout_branches
+
+checkout_branches_for_release:
+	BRANCH=$(python ../releases/releases/get_latest_version_number.py ../releases/releases.yml) checkout_branches
 
 make_addons_dir:
 	mkdir -p ${root_path}/liveobs_addons

--- a/gocd/Makefile
+++ b/gocd/Makefile
@@ -1,7 +1,5 @@
 #!/usr/bin/make
 
-root_path=..
-
 all: create_venv install_deps flake8 pylint make_addons_dir move_addons_into_dir
 
 create_venv:

--- a/gocd/Makefile
+++ b/gocd/Makefile
@@ -26,9 +26,6 @@ pylint:
 checkout_branches:
 	bash -c ./checkout_branches.sh
 
-checkout_branches_for_release:
-	BRANCH=$(python ../releases/releases/get_latest_version_number.py ../releases/releases.yml) bash -c ./checkout_branches.sh
-
 make_addons_dir:
 	mkdir -p ${root_path}/liveobs_addons
 

--- a/gocd/Makefile
+++ b/gocd/Makefile
@@ -22,10 +22,10 @@ pylint:
 	${root_path}/venv/bin/pylint --load-plugins=pylint_odoo --rcfile=../travis/cfg/travis_run_pylint.cfg ${root_path}/client_modules
 
 checkout_branches:
-	./checkout_branches.sh
+	bash -c checkout_branches.sh
 
 checkout_branches_for_release:
-	BRANCH=$(python ../releases/releases/get_latest_version_number.py ../releases/releases.yml) ./checkout_branches.sh
+	BRANCH=$(python ../releases/releases/get_latest_version_number.py ../releases/releases.yml) bash -c checkout_branches.sh
 
 make_addons_dir:
 	mkdir -p ${root_path}/liveobs_addons

--- a/gocd/Makefile
+++ b/gocd/Makefile
@@ -6,7 +6,7 @@ create_venv:
 	virtualenv ${root_path}/venv
 
 install_deps:
-	${root_path}/venv/bin/pip install -r requirements.txt
+	${root_path}/venv/bin/pip install -r ../requirements.txt
 	${root_path}/venv/bin/pip install -r ${root_path}/nhclinical/requirements.txt
 	${root_path}/venv/bin/pip install -r ${root_path}/openeobs/requirements.txt
 	${root_path}/venv/bin/pip install -r ${root_path}/BJSS_liveobs_client_modules/requirements.txt

--- a/gocd/Makefile
+++ b/gocd/Makefile
@@ -22,10 +22,10 @@ pylint:
 	${root_path}/venv/bin/pylint --load-plugins=pylint_odoo --rcfile=../travis/cfg/travis_run_pylint.cfg ${root_path}/client_modules
 
 checkout_branches:
-	bash -c checkout_branches.sh
+	bash -c ./checkout_branches.sh
 
 checkout_branches_for_release:
-	BRANCH=$(python ../releases/releases/get_latest_version_number.py ../releases/releases.yml) bash -c checkout_branches.sh
+	BRANCH=$(python ../releases/releases/get_latest_version_number.py ../releases/releases.yml) bash -c ./checkout_branches.sh
 
 make_addons_dir:
 	mkdir -p ${root_path}/liveobs_addons

--- a/gocd/Makefile
+++ b/gocd/Makefile
@@ -8,7 +8,7 @@ create_venv:
 	virtualenv ${root_path}/venv
 
 install_deps:
-	${root_path}/venv/bin/pip install -r requirements.txt
+	${root_path}/venv/bin/pip install -r ${root_path}/requirements.txt
 	${root_path}/venv/bin/pip install -r ${root_path}/../nhclinical/requirements.txt
 	${root_path}/venv/bin/pip install -r ${root_path}/../openeobs/requirements.txt
 	${root_path}/venv/bin/pip install -r ${root_path}/../client_modules/requirements.txt

--- a/gocd/Makefile
+++ b/gocd/Makefile
@@ -11,17 +11,17 @@ install_deps:
 	${root_path}/venv/bin/pip install -r ${root_path}/requirements.txt
 	${root_path}/venv/bin/pip install -r ${root_path}/../nhclinical/requirements.txt
 	${root_path}/venv/bin/pip install -r ${root_path}/../openeobs/requirements.txt
-	${root_path}/venv/bin/pip install -r ${root_path}/../client_modules/requirements.txt
+	${root_path}/venv/bin/pip install -r ${root_path}/../BJSS_liveobs_client_modules/requirements.txt
 
 flake8:
 	${root_path}/venv/bin/flake8 --config=../travis/cfg/travis_run_flake8.cfg ${root_path}/nhclinical
 	${root_path}/venv/bin/flake8 --config=../travis/cfg/travis_run_flake8.cfg ${root_path}/openeobs
-	${root_path}/venv/bin/flake8 --config=../travis/cfg/travis_run_flake8.cfg ${root_path}/client_modules
+	${root_path}/venv/bin/flake8 --config=../travis/cfg/travis_run_flake8.cfg ${root_path}/BJSS_liveobs_client_modules
 
 pylint:
 	${root_path}/venv/bin/pylint --load-plugins=pylint_odoo --rcfile=../travis/cfg/travis_run_pylint.cfg ${root_path}/nhclinical
 	${root_path}/venv/bin/pylint --load-plugins=pylint_odoo --rcfile=../travis/cfg/travis_run_pylint.cfg ${root_path}/openeobs
-	${root_path}/venv/bin/pylint --load-plugins=pylint_odoo --rcfile=../travis/cfg/travis_run_pylint.cfg ${root_path}/client_modules
+	${root_path}/venv/bin/pylint --load-plugins=pylint_odoo --rcfile=../travis/cfg/travis_run_pylint.cfg ${root_path}/BJSS_liveobs_client_modules
 
 checkout_branches:
 	bash -c ./checkout_branches.sh
@@ -37,6 +37,6 @@ move_addons_into_dir:
     # i.e. 'nhclinical' itself is not copied.
 	/bin/bash -c "find ${root_path}/nhclinical -maxdepth 1 -type d ! -regex '\.\/\..*' -not -name \".\" -exec cp -r {}  ${root_path}/liveobs_addons \;"
 	/bin/bash -c "find ${root_path}/openeobs -maxdepth 1 -type d ! -regex '\.\/\..*' -not -name \".\" -exec cp -r {}  ${root_path}/liveobs_addons \;"
-	/bin/bash -c "find ${root_path}/client_modules -maxdepth 1 -type d ! -regex '\.\/\..*' -not -name \".\" -exec cp -r {}  ${root_path}/liveobs_addons \;"
+	/bin/bash -c "find ${root_path}/BJSS_liveobs_client_modules -maxdepth 1 -type d ! -regex '\.\/\..*' -not -name \".\" -exec cp -r {}  ${root_path}/liveobs_addons \;"
 
 .PHONY: create_venv install_deps flake8 pylint make_addons_dir move_addons_into_dir

--- a/gocd/Makefile
+++ b/gocd/Makefile
@@ -4,17 +4,14 @@ root_path=..
 
 all: create_venv install_deps flake8 pylint make_addons_dir move_addons_into_dir
 
-print_foobar:
-	cat ${root_path}/version_branch.txt
-
 create_venv:
 	virtualenv ${root_path}/venv
 
 install_deps:
-	${root_path}/venv/bin/pip install -r ../requirements.txt
-	${root_path}/venv/bin/pip install -r ${root_path}/nhclinical/requirements.txt
-	${root_path}/venv/bin/pip install -r ${root_path}/openeobs/requirements.txt
-	${root_path}/venv/bin/pip install -r ${root_path}/client_modules/requirements.txt
+	${root_path}/venv/bin/pip install -r requirements.txt
+	${root_path}/venv/bin/pip install -r ${root_path}/../nhclinical/requirements.txt
+	${root_path}/venv/bin/pip install -r ${root_path}/../openeobs/requirements.txt
+	${root_path}/venv/bin/pip install -r ${root_path}/../client_modules/requirements.txt
 
 flake8:
 	${root_path}/venv/bin/flake8 --config=../travis/cfg/travis_run_flake8.cfg ${root_path}/nhclinical

--- a/gocd/checkout_branches.sh
+++ b/gocd/checkout_branches.sh
@@ -17,7 +17,7 @@ if [[ -z "${BRANCH}" ]]
 	OPENEOBS_DATE=$(git show "${OPENEOBS_HASH}" -s --format="%at")
 
 	CLIENT_HASH=$GO_SCM_CLIENT_MODULES_LABEL
-	cd ../client_modules
+	cd ../BJSS_liveobs_client_modules
 	CLIENT_DATE=$(git show "${CLIENT_HASH}" -s --format="%at")
 
 	# Need to then compare all 3 hashes. Which one is the latest?
@@ -41,7 +41,7 @@ git checkout -f $BRANCH || git checkout $BASE_BRANCH
 cd ../openeobs
 git fetch
 git checkout -f $BRANCH || git checkout $BASE_BRANCH
-cd ../client_modules
+cd ../BJSS_liveobs_client_modules
 git fetch
 git checkout -f $BRANCH || git checkout $BASE_BRANCH
 cd ..

--- a/gocd/checkout_branches.sh
+++ b/gocd/checkout_branches.sh
@@ -45,4 +45,9 @@ cd ../BJSS_liveobs_client_modules
 git fetch
 git checkout -f $BRANCH || git checkout $BASE_BRANCH
 cd ..
-echo $BRANCH > version_branch.txt
+
+VERSION_NAME=$BRANCH
+VERSION_NAME+=_
+VERSION_NAME+=$GO_PIPELINE_LABEL
+
+echo $VERSION_NAME > version_branch.txt

--- a/gocd/checkout_branches.sh
+++ b/gocd/checkout_branches.sh
@@ -1,44 +1,48 @@
 #!/bin/bash
+# If no BRANCH environment variable provided, then being run on GoCD, so
+# determine which PR branch was actually the one that triggered the build.
+# Otherwise just use the existing BRANCH environment variable.
+if [[ -z "${BRANCH}" ]]
+  then
+	NHCLINICAL_BRANCH=$(echo $GO_SCM_NHCLINICAL_PR_BRANCH | sed 's/NeovaHealth://')
+	OPENEOBS_BRANCH=$(echo $GO_SCM_OPEN_EOBS_PR_BRANCH | sed 's/NeovaHealth://')
+	CLIENT_BRANCH=$(echo $GO_SCM_CLIENT_MODULES_PR_BRANCH | sed 's/bjss://')
+
+	NHCLINICAL_HASH=$GO_SCM_NHCLINICAL_LABEL
+	cd ../nhclinical
+	NHCLINICAL_DATE=$(git show "${NHCLINICAL_HASH}" -s --format="%at")
+
+	OPENEOBS_HASH=$GO_SCM_OPEN_EOBS_LABEL
+	cd ../openeobs
+	OPENEOBS_DATE=$(git show "${OPENEOBS_HASH}" -s --format="%at")
+
+	CLIENT_HASH=$GO_SCM_CLIENT_MODULES_LABEL
+	cd ../client_modules
+	CLIENT_DATE=$(git show "${CLIENT_HASH}" -s --format="%at")
+
+	# Need to then compare all 3 hashes. Which one is the latest?
+	if [ ${NHCLINICAL_DATE} -gt ${OPENEOBS_DATE} -a ${NHCLINICAL_DATE} -gt ${CLIENT_DATE} ] ; then
+		BRANCH=$NHCLINICAL_BRANCH
+	fi
+	if [ ${OPENEOBS_DATE} -gt ${NHCLINICAL_DATE} -a ${OPENEOBS_DATE} -gt ${CLIENT_DATE} ] ; then
+		BRANCH=$OPENEOBS_BRANCH
+	fi
+	if [ ${CLIENT_DATE} -gt ${NHCLINICAL_DATE} -a ${CLIENT_DATE} -gt ${OPENEOBS_DATE} ] ; then
+		BRANCH=$CLIENT_BRANCH
+	fi
+fi
+
+# Checkout branch. If branch does not exist fall back to develop.
 BASE_BRANCH="develop"
-BRANCH=$BASE_BRANCH
 
-NHCLINICAL_BRANCH=$(echo $GO_SCM_NHCLINICAL_PR_BRANCH | sed 's/NeovaHealth://')
-OPENEOBS_BRANCH=$(echo $GO_SCM_OPEN_EOBS_PR_BRANCH | sed 's/NeovaHealth://')
-CLIENT_BRANCH=$(echo $GO_SCM_CLIENT_MODULES_PR_BRANCH | sed 's/bjss://')
-
-NHCLINICAL_HASH=$GO_SCM_NHCLINICAL_LABEL
-cd ../nhclinical
-NHCLINICAL_DATE=$(git show "${NHCLINICAL_HASH}" -s --format="%at")
-
-OPENEOBS_HASH=$GO_SCM_OPEN_EOBS_LABEL
-cd ../openeobs
-OPENEOBS_DATE=$(git show "${OPENEOBS_HASH}" -s --format="%at")
-
-CLIENT_HASH=$GO_SCM_CLIENT_MODULES_LABEL
-cd ../client_modules
-CLIENT_DATE=$(git show "${CLIENT_HASH}" -s --format="%at")
-
-# Need to then compare all 3 hashes
-if [ ${NHCLINICAL_DATE} -gt ${OPENEOBS_DATE} -a ${NHCLINICAL_DATE} -gt ${CLIENT_DATE} ] ; then
-    BRANCH=$NHCLINICAL_BRANCH
-fi
-if [ ${OPENEOBS_DATE} -gt ${NHCLINICAL_DATE} -a ${OPENEOBS_DATE} -gt ${CLIENT_DATE} ] ; then
-    BRANCH=$OPENEOBS_BRANCH
-fi
-if [ ${CLIENT_DATE} -gt ${NHCLINICAL_DATE} -a ${CLIENT_DATE} -gt ${OPENEOBS_DATE} ] ; then
-    BRANCH=$CLIENT_BRANCH
-fi
 cd ../nhclinical
 git fetch
-git checkout $BASE_BRANCH
-git checkout -f $BRANCH || true
+git checkout -f $BRANCH || git checkout $BASE_BRANCH
 cd ../openeobs
 git fetch
-git checkout $BASE_BRANCH
-git checkout -f $BRANCH || true
+git checkout -f $BRANCH || git checkout $BASE_BRANCH
 cd ../client_modules
 git fetch
-git checkout $BASE_BRANCH
-git checkout -f $BRANCH || true
+git checkout -f $BRANCH || git checkout $BASE_BRANCH
 cd ..
 echo $BRANCH > version_branch.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,7 @@ isort
 polib
 slumber
 transifex-client
+
+# Makefile requirements
+pylint==1.7.2
+flake8==3.4.1


### PR DESCRIPTION
Changed file paths used in `Makefile` from `client_modules` to `BJSS_liveobs_client_modules`. I feel this is a good practice just because it is the most obvious default name for the location of the git repo (as this is what git clone would use without any args) and therefore adopting this naming convention will be the simplest to adhere to across pipelines.

Made the `checkout_branches.sh` script overridable with environment variables so that it could be reused in other pipelines.