### PR TITLE
- Adding job to set the branch in the sonar properties file

### DIFF
--- a/gocd/Makefile
+++ b/gocd/Makefile
@@ -30,7 +30,10 @@ move_addons_into_dir:
 	/bin/bash -c "rm -rf ${root_path}/liveobs_addons/openeobs"
 	/bin/bash -c "rm -rf ${root_path}/liveobs_addons/BJSS_liveobs_client_modules"
 
+set_sonar_branch:
+	/bin/bash -c "cut -d'_' -f1 <<< cat ${root_path}/version_branch.txt | tr -d '\n' >> sonar-project.properties"
+
 run_sonar_scanner:
 	sonar-scanner -Dproject.settings=sonar-project.properties -X
 
-.PHONY: create_venv install_deps flake8 pylint make_addons_dir move_addons_into_dir run_sonar_scanner
+.PHONY: create_venv install_deps flake8 pylint make_addons_dir move_addons_into_dir set_sonar_branch run_sonar_scanner

--- a/gocd/Makefile
+++ b/gocd/Makefile
@@ -31,6 +31,8 @@ move_addons_into_dir:
 	/bin/bash -c "rm -rf ${root_path}/liveobs_addons/BJSS_liveobs_client_modules"
 
 set_sonar_branch:
+    # Split the value in version_branch.txt on the '_' character into an array and use the first part (which is the branch name) to append the sonar-branch
+    # property to the sonar-project.properties file. This will allow for branches to be used in SonarQube
 	/bin/bash -c "echo sonar-branch=$(cut -d'_' -f1 <<< cat ${root_path}/version_branch.txt | tr -d '\n') >> sonar-project.properties"
 
 run_sonar_scanner:

--- a/gocd/Makefile
+++ b/gocd/Makefile
@@ -31,7 +31,7 @@ move_addons_into_dir:
 	/bin/bash -c "rm -rf ${root_path}/liveobs_addons/BJSS_liveobs_client_modules"
 
 set_sonar_branch:
-	/bin/bash -c "cut -d'_' -f1 <<< cat ${root_path}/version_branch.txt | tr -d '\n' >> sonar-project.properties"
+	/bin/bash -c "echo sonar-branch=$(cut -d'_' -f1 <<< cat ${root_path}/version_branch.txt | tr -d '\n') >> sonar-project.properties"
 
 run_sonar_scanner:
 	sonar-scanner -Dproject.settings=sonar-project.properties -X


### PR DESCRIPTION
Adding a job which gets the branch from version_branch.txt, removes the number from it and puts that into  the sonar-project.properties file